### PR TITLE
Instructions

### DIFF
--- a/Quadriscan/Internals/CRT.cs
+++ b/Quadriscan/Internals/CRT.cs
@@ -36,6 +36,8 @@ internal class CRT {
     }
 
     private void setPixel(int x, int y, Color color) {
+        if (width <= x || x < 0) return;
+        if (height <= y || y < 0) return;
         buffer[x + y * width] = color;
     }
 

--- a/Quadriscan/Internals/VectorGenerator.cs
+++ b/Quadriscan/Internals/VectorGenerator.cs
@@ -1,15 +1,21 @@
+using System.Collections.Generic;
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+
+using Quadriscan.Instructions;
 
 namespace Quadriscan.Internals;
 
 internal static class VectorGenerator {
     private static CRT monitor;
     private static Beam beam;
+    private static List<Action<Beam>> instructions;
 
     public static void initialize(GraphicsDevice g, uint width, uint height) {
         monitor = new(g, width, height);
         beam = new();
+        instructions = new();
     }
 
     public static void Position(Point p) {
@@ -18,12 +24,21 @@ internal static class VectorGenerator {
 
     public static void Position(int dx, int dy) => Position(new(dx, dy));
 
-    public static void Draw(Point p) {
+    public static void Draw(Point p, byte brightness = 15) {
+        beam.Brightness = brightness;
         beam.Move(p);
         monitor.DrawLine(beam.LastPath(), beam.GetColor());
     }
 
-    public static void Draw(int dx, int dy) => Draw(new(dx, dy));
+    public static void Draw(int dx, int dy, byte brightness = 15) => Draw(new(dx, dy), brightness);
+
+    public static void Color(bool enabled, byte colorId, byte brightness) {
+        beam.setColor(enabled, colorId, brightness);
+    }
+
+    public static void Scale(byte digital, byte analog) {
+        beam.setScale(digital, analog);
+    }
 
     public static void Display() {
         monitor.Display();
@@ -31,15 +46,16 @@ internal static class VectorGenerator {
 
     public static void Testcat() {
         monitor.Blank();
+        Scale(1, 0);
         for (int i = 20; i < 400; i += 30) {
-            Position(i, 40);
+            Position(i, 80);
             // A
-            Draw(0, -20);
-            Draw(10, -10);
-            Draw(10, 10);
-            Draw(0, 20);
-            Draw(0, -10);
-            Draw(-20, 0);
+            Draw(0, -16, 15);
+            Draw(8, -8, 15);
+            Draw(8, 8, 15);
+            Draw(0, 16, 15);
+            Draw(0, -8, 15);
+            Draw(-16, 0, 15);
         }
         monitor.Display();
     }


### PR DESCRIPTION
This branch didn't really do as much as I wanted to. 
I initally wanted to create something similar to VRAM, where the programmer would store all of the instructions they wished to execute before executing them all at once. But then I realized that that was a waste of time. For one, I continually struggled to determine how I would even code something. My idea was to have a `VectorGenerator.Add(Instruction.Draw(x, y, brightness))`, but I had no idea what type the `Instruction.Draw` function would return. Also, it would be more convenient to run the instructions instead of storing them. So, I'll scale it back, and then I'll struggle to retrofit a more "legitimate" version later on. 

- Added SCALE instruction -- uses a "digital" and "analog" scale to determine how to scale vectors passed to the Beam. 
- Added COLOR instruction -- changes the color, intensity, and determines if the color is enabled at all. 
- Added POSITION instruction -- arbitrarily move the beam to some position before running an instruction. 
- Added DRAW instruction -- move the beam relative to its current position and trace a line at a certain brightness. 
- Renamed `Intensity` to `Brightness`
- Rescaled the test "A" drawing -- it turns out that it's 16x24, not 20x30. 
- Fixed a crash that can occur if the beam goes offscreen. 